### PR TITLE
Fixed problem with USB / I2C clash

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -20,7 +20,7 @@
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5---3rd-party-Hardware-specification
 
 name=Mysensors SAMD (32-bits ARM Cortex-M0+) Boards
-version=1.0.2
+version=1.0.3
 
 # Compile variables
 # -----------------

--- a/variants/mysensors_gw/variant.cpp
+++ b/variants/mysensors_gw/variant.cpp
@@ -141,6 +141,8 @@ const PinDescription g_APinDescription[]=
    | 42         | RFM_DIO5         |  PB05  |                 |    5   |  13 |     | Y11 |     |         |         |        |        |          |          |
    | 43         | RESET_RFM        |  PB10  |                 |   10   |     |     |     |     |         |   4/2   |  TC5/0 | TCC0/4 | I2S/MCK1 | GCLK_IO4 |
    | 44         | SECURITY         |  PA11  | ATSHA204        |   11   |  19 |     | X03 |     |   0/3   |   2/3   | TCC1/1 | TCC0/3 | I2S/FS0  | GCLK_IO5 |
+   | 45         |                  |  PA24  | USB_NEGATIVE    | *USB/DM
+   | 46         |                  |  PA25  | USB_POSITIVE    | *USB/DP
    +------------+------------------+--------+-----------------+--------+-----+-----+-----+-----+---------+---------+--------+--------+----------+----------+
    */
 
@@ -152,7 +154,9 @@ const PinDescription g_APinDescription[]=
   { PORTB,  1, PIO_DIGITAL, PIN_ATTR_DIGITAL,                             No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_1  },
   { PORTB,  5, PIO_DIGITAL, PIN_ATTR_DIGITAL,                             No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_5  },
   { PORTB, 10, PIO_DIGITAL, PIN_ATTR_DIGITAL,                             No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_6  },
-  { PORTA, 11, PIO_DIGITAL, PIN_ATTR_DIGITAL,                             No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE}
+  { PORTA, 11, PIO_DIGITAL, PIN_ATTR_DIGITAL,                             No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE},
+  { PORTA, 24, PIO_COM,     PIN_ATTR_NONE,                                No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // USB/DM
+  { PORTA, 25, PIO_COM,     PIN_ATTR_NONE,                                No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE } // USB/DP
 };
 
 const void* g_apTCInstances[TCC_INST_NUM+TC_INST_NUM]={ TCC0, TCC1, TCC2, TC3, TC4, TC5 } ;

--- a/variants/mysensors_gw/variant.h
+++ b/variants/mysensors_gw/variant.h
@@ -181,6 +181,8 @@ static const uint8_t SCK2 = PIN_SPI2_SCK;
 
 #define PIN_WIRE_SDA         (07u)
 #define PIN_WIRE_SCL         (06u)
+#define PERIPH_WIRE          sercom3
+#define WIRE_IT_HANDLER      SERCOM3_Handler
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;
@@ -188,9 +190,9 @@ static const uint8_t SCL = PIN_WIRE_SCL;
 /*
  * USB
  */
-#define PIN_USB_HOST_ENABLE (27ul)
-#define PIN_USB_DM (28ul)
-#define PIN_USB_DP (29ul)
+#define PIN_USB_HOST_ENABLE LED_ORANGE
+#define PIN_USB_DM (45ul)
+#define PIN_USB_DP (46ul)
 
 #ifdef __cplusplus
 }

--- a/variants/mysensors_gw/variant.h
+++ b/variants/mysensors_gw/variant.h
@@ -74,9 +74,9 @@ extern "C" {
 // #define digitalPinToTimer(P)
 
 // LEDs
-#define PIN_LED_13 (7u)
-#define PIN_LED_RXL (6u)
-#define PIN_LED_TXL (12u)
+#define PIN_LED_13 (16u)
+#define PIN_LED_RXL LED_ORANGE
+#define PIN_LED_TXL LED_ORANGE
 #define PIN_LED LED_BLUE
 #define PIN_LED2 LED_RED
 #define PIN_LED4 LED_GREEN


### PR DESCRIPTION
when USB received data, it would toggle a LED that was defined to be SCL on I2C bus, which effectively crashed the I2C driver. 
LED redefined to use a real LED on the board (LED_ORANGE)
